### PR TITLE
Fix Syslog.log to include string option

### DIFF
--- a/lib/logstasher/device/syslog.rb
+++ b/lib/logstasher/device/syslog.rb
@@ -52,7 +52,7 @@ module LogStasher
         fail ::RuntimeError, 'Cannot write. The device has been closed.' if closed?
 
         with_syslog_open do
-          ::Syslog.log(facility, log)
+          ::Syslog.log(facility, '%s', log)
         end
       end
 


### PR DESCRIPTION
Ruby's Syslog is expecting a `%s` formatter. Without it, syslog attempts to format anything that has a '%' in it. This fixes the issue.

@quixoten @abrandoned @mmmries @liveh2o 