### PR TITLE
Require logstash-event

### DIFF
--- a/lib/md-logstasher.rb
+++ b/lib/md-logstasher.rb
@@ -1,1 +1,2 @@
 require 'logstasher'
+require 'logstash-event'


### PR DESCRIPTION
We want to require logstash-event explicitly in order to have access to it in some of our apps. Just adding an explicit require.

@quixoten @mmmries @liveh2o @abrandoned