### PR TITLE
Push defaults config above initializers

### DIFF
--- a/lib/logstasher/railtie.rb
+++ b/lib/logstasher/railtie.rb
@@ -8,7 +8,7 @@ module LogStasher
     config.logstasher.logger = nil
     config.logstasher.log_level = ::Logger::INFO
 
-    initializer 'logstasher.configure' do
+    config.before_initialize do
       options = config.logstasher
 
       ::LogStasher.enabled                  = options.enabled


### PR DESCRIPTION
This will allow users to customize the logger in an initializer without worrying about the railtie overwriting them.